### PR TITLE
Fix broken anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,7 +715,7 @@ When you call `simpleSchemaInstance.clean()` with `trimStrings` set to `true`, a
 
 ### custom
 
-Refer to the [Custom Validation](#custom-validation) section.
+Refer to the [Custom Validation](#custom-field-validation) section.
 
 ### defaultValue
 


### PR DESCRIPTION
I think `#custom-field-validation` is a better link, isnt'it? `#custom-validation` anchor does not exist.