### PR TITLE
use Array.forEach to remove empty objects; fixes #244

### DIFF
--- a/package/lib/clean.js
+++ b/package/lib/clean.js
@@ -112,13 +112,14 @@ function clean(ss, doc, options = {}) {
     }, { endPointsOnly: false });
 
     // Remove any objects that are now empty after filtering
-    for (const removedPosition of removedPositions) {
+    removedPositions.forEach((removedPosition) => {
       const lastBrace = removedPosition.lastIndexOf('[');
-      if (lastBrace === -1) continue;
-      const removedPositionParent = removedPosition.slice(0, lastBrace);
-      const value = mongoObject.getValueForPosition(removedPositionParent);
-      if (isEmpty(value)) mongoObject.removeValueForPosition(removedPositionParent);
-    }
+      if (lastBrace !== -1) {
+        const removedPositionParent = removedPosition.slice(0, lastBrace);
+        const value = mongoObject.getValueForPosition(removedPositionParent);
+        if (isEmpty(value)) mongoObject.removeValueForPosition(removedPositionParent);
+      }
+    });
 
     mongoObject.removeArrayItems();
   }


### PR DESCRIPTION
Currently babel compiles the `for of` loop to a generator/iterator pattern. This is generally fine; however when using this package with react native this pattern seems to cause metro builder to crash and throw the error seen in #244. I believe this code is functionally equivalent and I have it running inside a react-native app and it does not cause the error. 