### PR TITLE
Allow allowedValues to be ES6 Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,9 +675,9 @@ Define the minimum or maximum array length. Used only when type is `Array`.
 
 ### allowedValues
 
-*Can also be a function that returns the array of allowed values*
+*Can also be a function that returns the array or the `Set` of allowed values*
 
-An array of values that are allowed. A key will be invalid if its value is not one of these.
+An array or a `Set` of values that are allowed. A key will be invalid if its value is not one of these.
 
 You can use `schema.getAllowedValuesForKey(key)` to get the allowed values array for a key.
 

--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -568,7 +568,16 @@ class SimpleSchema {
       key = `${key}.$`;
     }
 
-    return this.get(key, 'allowedValues');
+    const _allowedValues = this.get(key, 'allowedValues');
+    // Check if it is a Set. If yes, convert to array (prefer forEach instead of Array.from)
+    if (typeof Set === 'function' && _allowedValues instanceof Set) {
+      const _allowedValuesArray = [];
+      _allowedValues.forEach(function(value) {
+        _allowedValuesArray.push(value);
+      })
+      return _allowedValuesArray;
+    }
+    return _allowedValues;
   }
 
   newContext() {

--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -568,16 +568,7 @@ class SimpleSchema {
       key = `${key}.$`;
     }
 
-    const _allowedValues = this.get(key, 'allowedValues');
-    // Check if it is a Set. If yes, convert to array (prefer forEach instead of Array.from)
-    if (typeof Set === 'function' && _allowedValues instanceof Set) {
-      const _allowedValuesArray = [];
-      _allowedValues.forEach(function(value) {
-        _allowedValuesArray.push(value);
-      })
-      return _allowedValuesArray;
-    }
-    return _allowedValues;
+    return [...this.get(key, 'allowedValues')];
   }
 
   newContext() {

--- a/package/lib/SimpleSchema_allowedValues.tests.js
+++ b/package/lib/SimpleSchema_allowedValues.tests.js
@@ -5,6 +5,7 @@ import expect from 'expect';
 import friendsSchema from './testHelpers/friendsSchema';
 import testSchema from './testHelpers/testSchema';
 import expectErrorLength from './testHelpers/expectErrorLength';
+import 'babel-polyfill';
 
 describe('SimpleSchema - allowedValues', function () {
   describe('normal', function () {
@@ -18,7 +19,7 @@ describe('SimpleSchema - allowedValues', function () {
       }).toEqual(0);
 
       expectErrorLength(testSchema, {
-        allowedStringsSetOrArray: ['tuna', 'fish', 'salad'],
+        allowedStringsSet: ['tuna', 'fish', 'salad'],
       }).toEqual(0);
 
       // Array of objects
@@ -43,7 +44,7 @@ describe('SimpleSchema - allowedValues', function () {
 
       // Set Or Array
       expectErrorLength(testSchema, {
-        allowedStringsSetOrArray: ['tuna', 'fish', 'sandwich'],
+        allowedStringsSet: ['tuna', 'fish', 'sandwich'],
       }).toEqual(1);
 
       // Array of objects
@@ -66,7 +67,7 @@ describe('SimpleSchema - allowedValues', function () {
       }).toEqual(0);
 
       expectErrorLength(testSchema, {
-        allowedNumbersSetOrArray: [1, 2, 3],
+        allowedNumbersSet: [1, 2, 3],
       }).toEqual(0);
 
       // Array of objects
@@ -94,7 +95,7 @@ describe('SimpleSchema - allowedValues', function () {
 
       // Set or Array
       expectErrorLength(testSchema, {
-        allowedNumbersSetOrArray: [1, 2, 3, 4],
+        allowedNumbersSet: [1, 2, 3, 4],
       }).toEqual(1);
 
       // Array of objects
@@ -129,7 +130,7 @@ describe('SimpleSchema - allowedValues', function () {
       // Set or Array
       expectErrorLength(testSchema, {
         $setOnInsert: {
-          allowedStringsSetOrArray: ['tuna', 'fish', 'salad'],
+          allowedStringsSet: ['tuna', 'fish', 'salad'],
         },
       }, { modifier: true, upsert: true }).toEqual(0);
 
@@ -162,7 +163,7 @@ describe('SimpleSchema - allowedValues', function () {
       // Set or Array
       expectErrorLength(testSchema, {
         $setOnInsert: {
-          allowedStringsSetOrArray: ['tuna', 'fish', 'sandwich'],
+          allowedStringsSet: ['tuna', 'fish', 'sandwich'],
         },
       }, { modifier: true, upsert: true }).toEqual(1);
 
@@ -195,7 +196,7 @@ describe('SimpleSchema - allowedValues', function () {
       // Set or Array
       expectErrorLength(testSchema, {
         $setOnInsert: {
-          allowedNumbersSetOrArray: [1, 2, 3],
+          allowedNumbersSet: [1, 2, 3],
         },
       }, { modifier: true, upsert: true }).toEqual(0);
 
@@ -231,7 +232,7 @@ describe('SimpleSchema - allowedValues', function () {
       // Set or Array
       expectErrorLength(testSchema, {
         $setOnInsert: {
-          allowedNumbersSetOrArray: [1, 2, 3, 4],
+          allowedNumbersSet: [1, 2, 3, 4],
         },
       }, { modifier: true, upsert: true }).toEqual(1);
 
@@ -269,7 +270,7 @@ describe('SimpleSchema - allowedValues', function () {
       // Set or Array
       expectErrorLength(testSchema, {
         $set: {
-          allowedStringsSetOrArray: ['tuna', 'fish', 'salad'],
+          allowedStringsSet: ['tuna', 'fish', 'salad'],
         },
       }, { modifier: true }).toEqual(0);
 
@@ -304,7 +305,7 @@ describe('SimpleSchema - allowedValues', function () {
       // Set or Array
       expectErrorLength(testSchema, {
         $set: {
-          allowedStringsSetOrArray: ['tuna', 'fish', 'sandwich'],
+          allowedStringsSet: ['tuna', 'fish', 'sandwich'],
         },
       }, { modifier: true }).toEqual(1);
 
@@ -337,7 +338,7 @@ describe('SimpleSchema - allowedValues', function () {
 
       expectErrorLength(testSchema, {
         $set: {
-          allowedNumbersSetOrArray: [1, 2, 3],
+          allowedNumbersSet: [1, 2, 3],
         },
       }, { modifier: true }).toEqual(0);
     });
@@ -357,7 +358,7 @@ describe('SimpleSchema - allowedValues', function () {
 
       expectErrorLength(testSchema, {
         $set: {
-          allowedNumbersSetOrArray: [1, 2, 3, 4],
+          allowedNumbersSet: [1, 2, 3, 4],
         },
       }, { modifier: true }).toEqual(1);
     });
@@ -377,20 +378,18 @@ describe('SimpleSchema - allowedValues', function () {
     });
 
     it('works with set, convert to array', function () {
-      if (typeof Set === 'function') {
-        const allowedValues = new Set(['a', 'b']);
-        const schema = new SimpleSchema({
-          foo: Array,
-          'foo.$': {
-            type: String,
-            allowedValues,
-          },
-        });
-        const fetchedAllowedValues = schema.getAllowedValuesForKey('foo');
-        expect(fetchedAllowedValues).toInclude('a');
-        expect(fetchedAllowedValues).toInclude('b');
-        expect(fetchedAllowedValues.length).toEqual(2);
-      }
+      const allowedValues = new Set(['a', 'b']);
+      const schema = new SimpleSchema({
+        foo: Array,
+        'foo.$': {
+          type: String,
+          allowedValues,
+        },
+      });
+      const fetchedAllowedValues = schema.getAllowedValuesForKey('foo');
+      expect(fetchedAllowedValues).toInclude('a');
+      expect(fetchedAllowedValues).toInclude('b');
+      expect(fetchedAllowedValues.length).toEqual(2);
     });
   });
 });

--- a/package/lib/SimpleSchema_allowedValues.tests.js
+++ b/package/lib/SimpleSchema_allowedValues.tests.js
@@ -17,6 +17,10 @@ describe('SimpleSchema - allowedValues', function () {
         allowedStringsArray: ['tuna', 'fish', 'salad'],
       }).toEqual(0);
 
+      expectErrorLength(testSchema, {
+        allowedStringsSetOrArray: ['tuna', 'fish', 'salad'],
+      }).toEqual(0);
+
       // Array of objects
       expectErrorLength(friendsSchema, {
         friends: [{
@@ -37,6 +41,11 @@ describe('SimpleSchema - allowedValues', function () {
         allowedStringsArray: ['tuna', 'fish', 'sandwich'],
       }).toEqual(1);
 
+      // Set Or Array
+      expectErrorLength(testSchema, {
+        allowedStringsSetOrArray: ['tuna', 'fish', 'sandwich'],
+      }).toEqual(1);
+
       // Array of objects
       expectErrorLength(friendsSchema, {
         friends: [{
@@ -54,6 +63,10 @@ describe('SimpleSchema - allowedValues', function () {
 
       expectErrorLength(testSchema, {
         allowedNumbersArray: [1, 2, 3],
+      }).toEqual(0);
+
+      expectErrorLength(testSchema, {
+        allowedNumbersSetOrArray: [1, 2, 3],
       }).toEqual(0);
 
       // Array of objects
@@ -77,6 +90,11 @@ describe('SimpleSchema - allowedValues', function () {
       // Array
       expectErrorLength(testSchema, {
         allowedNumbersArray: [1, 2, 3, 4],
+      }).toEqual(1);
+
+      // Set or Array
+      expectErrorLength(testSchema, {
+        allowedNumbersSetOrArray: [1, 2, 3, 4],
       }).toEqual(1);
 
       // Array of objects
@@ -108,6 +126,13 @@ describe('SimpleSchema - allowedValues', function () {
         },
       }, { modifier: true, upsert: true }).toEqual(0);
 
+      // Set or Array
+      expectErrorLength(testSchema, {
+        $setOnInsert: {
+          allowedStringsSetOrArray: ['tuna', 'fish', 'salad'],
+        },
+      }, { modifier: true, upsert: true }).toEqual(0);
+
       // Array of objects
       expectErrorLength(friendsSchema, {
         $setOnInsert: {
@@ -131,6 +156,13 @@ describe('SimpleSchema - allowedValues', function () {
       expectErrorLength(testSchema, {
         $setOnInsert: {
           allowedStringsArray: ['tuna', 'fish', 'sandwich'],
+        },
+      }, { modifier: true, upsert: true }).toEqual(1);
+
+      // Set or Array
+      expectErrorLength(testSchema, {
+        $setOnInsert: {
+          allowedStringsSetOrArray: ['tuna', 'fish', 'sandwich'],
         },
       }, { modifier: true, upsert: true }).toEqual(1);
 
@@ -160,6 +192,13 @@ describe('SimpleSchema - allowedValues', function () {
         },
       }, { modifier: true, upsert: true }).toEqual(0);
 
+      // Set or Array
+      expectErrorLength(testSchema, {
+        $setOnInsert: {
+          allowedNumbersSetOrArray: [1, 2, 3],
+        },
+      }, { modifier: true, upsert: true }).toEqual(0);
+
       // Array of objects
       expectErrorLength(friendsSchema, {
         $setOnInsert: {
@@ -186,6 +225,13 @@ describe('SimpleSchema - allowedValues', function () {
       expectErrorLength(testSchema, {
         $setOnInsert: {
           allowedNumbersArray: [1, 2, 3, 4],
+        },
+      }, { modifier: true, upsert: true }).toEqual(1);
+
+      // Set or Array
+      expectErrorLength(testSchema, {
+        $setOnInsert: {
+          allowedNumbersSetOrArray: [1, 2, 3, 4],
         },
       }, { modifier: true, upsert: true }).toEqual(1);
 
@@ -220,6 +266,13 @@ describe('SimpleSchema - allowedValues', function () {
         },
       }, { modifier: true }).toEqual(0);
 
+      // Set or Array
+      expectErrorLength(testSchema, {
+        $set: {
+          allowedStringsSetOrArray: ['tuna', 'fish', 'salad'],
+        },
+      }, { modifier: true }).toEqual(0);
+
       // Array of objects
       expectErrorLength(friendsSchema, {
         $set: {
@@ -245,6 +298,13 @@ describe('SimpleSchema - allowedValues', function () {
       expectErrorLength(testSchema, {
         $set: {
           allowedStringsArray: ['tuna', 'fish', 'sandwich'],
+        },
+      }, { modifier: true }).toEqual(1);
+
+      // Set or Array
+      expectErrorLength(testSchema, {
+        $set: {
+          allowedStringsSetOrArray: ['tuna', 'fish', 'sandwich'],
         },
       }, { modifier: true }).toEqual(1);
 
@@ -274,6 +334,12 @@ describe('SimpleSchema - allowedValues', function () {
           allowedNumbersArray: [1, 2, 3],
         },
       }, { modifier: true }).toEqual(0);
+
+      expectErrorLength(testSchema, {
+        $set: {
+          allowedNumbersSetOrArray: [1, 2, 3],
+        },
+      }, { modifier: true }).toEqual(0);
     });
 
     it('invalid number', function () {
@@ -286,6 +352,12 @@ describe('SimpleSchema - allowedValues', function () {
       expectErrorLength(testSchema, {
         $set: {
           allowedNumbersArray: [1, 2, 3, 4],
+        },
+      }, { modifier: true }).toEqual(1);
+
+      expectErrorLength(testSchema, {
+        $set: {
+          allowedNumbersSetOrArray: [1, 2, 3, 4],
         },
       }, { modifier: true }).toEqual(1);
     });
@@ -302,6 +374,23 @@ describe('SimpleSchema - allowedValues', function () {
         },
       });
       expect(schema.getAllowedValuesForKey('foo')).toEqual(allowedValues);
+    });
+
+    it('works with set, convert to array', function () {
+      if (typeof Set === 'function') {
+        const allowedValues = new Set(['a', 'b']);
+        const schema = new SimpleSchema({
+          foo: Array,
+          'foo.$': {
+            type: String,
+            allowedValues,
+          },
+        });
+        const fetchedAllowedValues = schema.getAllowedValuesForKey('foo');
+        expect(fetchedAllowedValues).toInclude('a');
+        expect(fetchedAllowedValues).toInclude('b');
+        expect(fetchedAllowedValues.length).toEqual(2);
+      }
     });
   });
 });

--- a/package/lib/testHelpers/testSchema.js
+++ b/package/lib/testHelpers/testSchema.js
@@ -1,5 +1,6 @@
 import { SimpleSchema } from '../SimpleSchema';
 import Address from './Address';
+import 'babel-polyfill';
 
 const testSchema = new SimpleSchema({
   string: {
@@ -37,15 +38,13 @@ const testSchema = new SimpleSchema({
     type: String,
     allowedValues: ['tuna', 'fish', 'salad'],
   },
-  allowedStringsSetOrArray: { // make sure test always runnable even without Set
+  allowedStringsSet: {
     type: Array,
     optional: true,
   },
-  'allowedStringsSetOrArray.$': {
+  'allowedStringsSet.$': {
     type: String,
-    allowedValues: typeof Set === 'function' ?
-      new Set(['tuna', 'fish', 'salad']) :
-      ['tuna', 'fish', 'salad'],
+    allowedValues: new Set(['tuna', 'fish', 'salad']),
   },
   boolean: {
     type: Boolean,
@@ -125,15 +124,13 @@ const testSchema = new SimpleSchema({
     type: SimpleSchema.Integer,
     allowedValues: [1, 2, 3],
   },
-  allowedNumbersSetOrArray: {
+  allowedNumbersSet: {
     type: Array,
     optional: true,
   },
-  'allowedNumbersSetOrArray.$': {
+  'allowedNumbersSet.$': {
     type: SimpleSchema.Integer,
-    allowedValues: typeof Set === 'function' ?
-      new Set([1, 2, 3]) :
-      [1, 2, 3],
+    allowedValues: new Set([1, 2, 3]),
   },
   decimal: {
     type: Number,

--- a/package/lib/testHelpers/testSchema.js
+++ b/package/lib/testHelpers/testSchema.js
@@ -37,6 +37,16 @@ const testSchema = new SimpleSchema({
     type: String,
     allowedValues: ['tuna', 'fish', 'salad'],
   },
+  allowedStringsSetOrArray: { // make sure test always runnable even without Set
+    type: Array,
+    optional: true,
+  },
+  'allowedStringsSetOrArray.$': {
+    type: String,
+    allowedValues: typeof Set === 'function' ?
+      new Set(['tuna', 'fish', 'salad']) :
+      ['tuna', 'fish', 'salad'],
+  },
   boolean: {
     type: Boolean,
     optional: true,
@@ -114,6 +124,16 @@ const testSchema = new SimpleSchema({
   'allowedNumbersArray.$': {
     type: SimpleSchema.Integer,
     allowedValues: [1, 2, 3],
+  },
+  allowedNumbersSetOrArray: {
+    type: Array,
+    optional: true,
+  },
+  'allowedNumbersSetOrArray.$': {
+    type: SimpleSchema.Integer,
+    allowedValues: typeof Set === 'function' ?
+      new Set([1, 2, 3]) :
+      [1, 2, 3],
   },
   decimal: {
     type: Number,

--- a/package/lib/validation/allowedValuesValidator.js
+++ b/package/lib/validation/allowedValuesValidator.js
@@ -7,6 +7,13 @@ export default function allowedValuesValidator() {
   const allowedValues = this.definition.allowedValues;
   if (!allowedValues) return;
 
-  const isAllowed = includes(allowedValues, this.value);
+  let isAllowed;
+  // set defined in scope and allowedValues is its instance
+  if (typeof Set === 'function' && allowedValues instanceof Set) {
+    isAllowed = allowedValues.has(this.value);
+  } else {
+    isAllowed = includes(allowedValues, this.value);
+  }
+
   return isAllowed ? true : SimpleSchema.ErrorTypes.VALUE_NOT_ALLOWED;
 }

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simpl-schema",
-  "version": "1.4.0",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package/package.json
+++ b/package/package.json
@@ -46,6 +46,7 @@
     "babel-cli": "^6.10.1",
     "babel-core": "^6.9.1",
     "babel-eslint": "^6.0.4",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-0": "^6.5.0",


### PR DESCRIPTION
Allowing `allowedValues` to be ES6 `Set`. Make sure that `Set` exists in scope. Modified `schema.getAllowedValuesForKey` to convert `Set` for Array to keep the original doc requirement