### PR TITLE
Attempt to fix #272 : autovalues change $pull condition 

### DIFF
--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -894,6 +894,10 @@ function getDefaultAutoValueFunction(defaultValue) {
     if (this.isSet) return;
     if (this.operator === null) return defaultValue;
 
+    // Handle the case when pulling an object from an array the object contains a field
+    // which has a defaultValue. We don't wan't the default value to be returned in this case
+    if (this.operator === '$pull') return;
+
     // Handle the case where we are $pushing an object into an array of objects and we
     // want any fields missing from that object to be added if they have default values
     if (this.operator === '$push') return defaultValue;

--- a/package/lib/clean.tests.js
+++ b/package/lib/clean.tests.js
@@ -51,6 +51,17 @@ const ss = new SimpleSchema({
   'booleanArray.$': {
     type: Boolean,
   },
+  objectArray: {
+    type: Array,
+    optional: true,
+  },
+  'objectArray.$': {
+    type: Object,
+  },
+  'objectArray.$.boolean': {
+    type: Boolean,
+    defaultValue: false,
+  },
   number: {
     type: SimpleSchema.Integer,
     optional: true,
@@ -270,6 +281,7 @@ describe('clean', function () {
 
   describe('$pull', function () {
     it('when you clean a good object it is still good', getTest({ $pull: { allowedNumbersArray: 1 } }, { $pull: { allowedNumbersArray: 1 } }, true));
+    it('when you clean a good object with defaultValue it is still good', getTest({ $pull: { objectArray: { boolean: true } } }, { $pull: { objectArray: { boolean: true } } }, true));
     it('when you clean a bad object it is now good', getTest({ $pull: { allowedNumbersArray: 1, admin: 1 } }, { $pull: { allowedNumbersArray: 1 } }, true));
     it('type conversion works', getTest({ $pull: { allowedNumbersArray: '1' } }, { $pull: { allowedNumbersArray: 1 } }, true));
   });


### PR DESCRIPTION
@aldeed I don't know how to test this in real conditions (i.e. how to import simple schema in my meteor app from my cloned repo, overiding the npm version) so I am not sure it's working. However, the test case I wrote effectively broke, and the fix proposed in the second commit fixed it.