### PR TITLE
Implementing Any type from #169

### DIFF
--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -372,8 +372,6 @@ class SimpleSchema {
           testKeySchema.type.definitions.forEach(typeDef => {
             if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
             if (typeDef.type.keyIsInBlackBox(remainder)) isInBlackBox = true;
-            // Also consider parents with type: SimpleSchema.Any as blackboxed
-            if (typeDef.type === SimpleSchema.Any) isInBlackBox = true;
           });
         }
       }

--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -810,6 +810,8 @@ class SimpleSchema {
     return new SimpleSchemaGroup(...definitions);
   }
 
+  static Any = '___Any___';
+
   static RegEx = regExpObj;
 
   // Global custom validators

--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -372,6 +372,8 @@ class SimpleSchema {
           testKeySchema.type.definitions.forEach(typeDef => {
             if (!(SimpleSchema.isSimpleSchema(typeDef.type))) return;
             if (typeDef.type.keyIsInBlackBox(remainder)) isInBlackBox = true;
+            // Also consider parents with type: SimpleSchema.Any as blackboxed
+            if (typeDef.type === SimpleSchema.Any) isInBlackBox = true;
           });
         }
       }
@@ -519,7 +521,8 @@ class SimpleSchema {
       // Keep list of all blackbox keys for passing to MongoObject constructor
       // XXX For now if any oneOf type is blackbox, then the whole field is.
       every(definition.type.definitions, (oneOfDef) => {
-        if (oneOfDef.blackbox === true) {
+        // XXX If the type is SS.Any, also consider it a blackbox
+        if (oneOfDef.blackbox === true || oneOfDef.type === SimpleSchema.Any) {
           this._blackboxKeys.push(fieldName);
           return false; // exit loop
         }

--- a/package/lib/SimpleSchema.tests.js
+++ b/package/lib/SimpleSchema.tests.js
@@ -1062,70 +1062,140 @@ describe('SimpleSchema', function () {
     const schema = new SimpleSchema({
       testAny: SimpleSchema.Any,
     });
-    it('can be used to allow a key with string', function () {
-      expectValid(schema, {
-        testAny: 'string',
-      });
-    });
-    it('can be used to allow a key with 42', function () {
-      expectValid(schema, {
-        testAny: 42,
-      });
-    });
-    it('can be used to allow a key with 3.1415', function () {
-      expectValid(schema, {
-        testAny: 3.1415,
-      });
-    });
-    it('can be used to allow a key with []', function () {
-      expectValid(schema, {
-        testAny: [],
+    describe('can be used to allow a key with type', function () {
+      const dataTypes = [
+        ["String 'string'", 'string'],
+        ['Number 42', 42],
+        ['Number 3.1415', 3.1415],
+        ['Array []', []],
+        ["Array ['string']", ['string']],
+        ['Object { }', { }],
+        ['Object { test: true }', { test: true }],
+        ['Number NaN', NaN],
+        ['Date new Date()', new Date()],
+        ['Boolean true', true],
+        ['Boolean false', false],
+      ];
+
+      dataTypes.forEach(([label, type]) => {
+        describe(label, function () {
+          it("on it's own", function () {
+            expectValid(schema, { testAny: type });
+          });
+
+          it('as a nested key', function () {
+            expectValid(
+              new SimpleSchema({ testNested: schema }),
+              { testNested: { testAny: { test: type } } }
+            );
+          });
+        });
       });
     });
 
-    it('can be used to allow a key with ["string"]', function () {
-      expectValid(schema, {
-        testAny: ['string'],
+    describe('with modifiers', function() {
+      const shouldBeValidModifiers = [
+        '$set',
+        '$setOnInsert',
+        '$inc',
+        '$dec',
+        '$min',
+        '$max',
+        '$mul',
+        '$pop',
+        '$pull',
+        '$pullAll',
+      ];
+      shouldBeValidModifiers.forEach(mod => {
+        describe(mod, function () {
+          it(`can be used for ${mod} modifiers`, function() {
+            expectValid(
+              schema,
+              { [mod]: { testAny: 3.1415 } },
+              { modifier: true }
+            );
+          });
+          it(`can be used for nested ${mod} modifiers`, function() {
+            const parentSchema = new SimpleSchema({ parent: schema });
+            expectValid(
+              parentSchema,
+              { [mod]: { parent: { testAny: 3.1415 } } },
+              { modifier: true }
+            );
+          });
+          it(`can be used for nested ${mod} modifiers with dot notation`, function() {
+            const parentSchema = new SimpleSchema({ parent: schema });
+            expectValid(
+              parentSchema,
+              { [mod]: { 'parent.testAny': 3.1415 } },
+              { modifier: true }
+            );
+          });
+        });
       });
-    });
-    it('can be used to allow a key with { }', function () {
-      expectValid(schema, {
-        testAny: {},
+
+      // Special cases where we don't expect it to work like the rest:
+      describe('$unset', function () {
+        it('can be used for $unset modifiers', function() {
+          expectErrorOfTypeLength(
+            SimpleSchema.ErrorTypes.REQUIRED,
+            schema,
+            { $unset: { testAny: 1 } },
+            { modifier: true }
+          ).toEqual(1);
+        });
+        it('can be used for nested $unset modifiers', function() {
+          const parentSchema = new SimpleSchema({ parent: schema });
+          expectErrorOfTypeLength(
+            SimpleSchema.ErrorTypes.REQUIRED,
+            parentSchema,
+            { $unset: { parent: 1 } },
+            { modifier: true }
+          ).toEqual(1);
+        });
+        it('can be used for nested $unset modifiers with dot notation', function() {
+          const parentSchema = new SimpleSchema({ parent: schema });
+          expectErrorOfTypeLength(
+            SimpleSchema.ErrorTypes.REQUIRED,
+            parentSchema,
+            { $unset: { 'parent.testAny': 1 } },
+            { modifier: true }
+          ).toEqual(1);
+        });
       });
-    });
-    it('can be used to allow a key with { test: true }', function () {
-      expectValid(schema, {
-        testAny: { test: true },
+      describe('$addToSet', function () {
+        it('can be used for $addToSet modifiers', function() {
+          expectValid(
+            schema,
+            { $addToSet: { testAny: 1 } },
+            { modifier: true }
+          );
+        });
+        it('can be used for nested $addToSet modifiers with dot notation', function() {
+          const parentSchema = new SimpleSchema({ parent: schema });
+          expectValid(
+            parentSchema,
+            { $addToSet: { 'parent.testAny': 3.1415 } },
+            { modifier: true }
+          );
+        });
       });
-    });
-    it('can be used to allow a key with { test: true }', function () {
-      expectValid(
-        new SimpleSchema({
-          testNested: schema,
-        }),
-        {
-          testNested: { testAny: { test: true } },
-        }
-      );
-    });
-    it('can be used to allow a key with NaN', function () {
-      expectValid(schema, {
-        testAny: NaN,
-      });
-    });
-    it('can be used to allow a key with new Date()', function () {
-      expectValid(schema, {
-        testAny: new Date(),
-      });
-    });
-    it('can be used to allow a key with true', function () {
-      expectValid(schema, {
-        testAny: true,
-      });
-    });
-    it('can be used to allow a key with false', function () {
-      expectValid(schema, {
-        testAny: false,
+      describe('$push', function () {
+        it('can be used for $push modifiers', function() {
+          expectValid(
+            schema,
+            { $push: { testAny: 1 } },
+            { modifier: true }
+            );
+        });
+        it('can be used for nested $push modifiers with dot notation', function() {
+          const parentSchema = new SimpleSchema({ parent: schema });
+          expectValid(
+            parentSchema,
+            { $push: { 'parent.testAny': 3.1415 } },
+            { modifier: true }
+          );
+        });
       });
     });
   });

--- a/package/lib/SimpleSchema.tests.js
+++ b/package/lib/SimpleSchema.tests.js
@@ -1057,4 +1057,61 @@ describe('SimpleSchema', function () {
 
     expect(foo instanceof SimpleSchema).toBe(true);
   });
+
+  describe('SimpleSchema.Any', function () {
+    const schema = new SimpleSchema({
+      testAny: SimpleSchema.Any,
+    });
+    it('can be used to allow a key with string', function () {
+      expectValid(schema, {
+        testAny: 'string',
+      });
+    });
+    it('can be used to allow a key with 42', function () {
+      expectValid(schema, {
+        testAny: 42,
+      });
+    });
+    it('can be used to allow a key with 3.1415', function () {
+      expectValid(schema, {
+        testAny: 3.1415,
+      });
+    });
+    it('can be used to allow a key with []', function () {
+      expectValid(schema, {
+        testAny: [],
+      });
+    });
+    // Fails...
+    it('can be used to allow a key with ["string"]', function () {
+      expectValid(schema, {
+        testAny: ['string'],
+      });
+    });
+    it('can be used to allow a key with { test: true }', function () {
+      expectValid(schema, {
+        testAny: { test: true },
+      });
+    });
+    it('can be used to allow a key with NaN', function () {
+      expectValid(schema, {
+        testAny: NaN,
+      });
+    });
+    it('can be used to allow a key with new Date()', function () {
+      expectValid(schema, {
+        testAny: new Date(),
+      });
+    });
+    it('can be used to allow a key with true', function () {
+      expectValid(schema, {
+        testAny: true,
+      });
+    });
+    it('can be used to allow a key with false', function () {
+      expectValid(schema, {
+        testAny: false,
+      });
+    });
+  });
 });

--- a/package/lib/SimpleSchema.tests.js
+++ b/package/lib/SimpleSchema.tests.js
@@ -1082,7 +1082,7 @@ describe('SimpleSchema', function () {
         testAny: [],
       });
     });
-    
+
     it('can be used to allow a key with ["string"]', function () {
       expectValid(schema, {
         testAny: ['string'],

--- a/package/lib/SimpleSchema.tests.js
+++ b/package/lib/SimpleSchema.tests.js
@@ -1082,16 +1082,31 @@ describe('SimpleSchema', function () {
         testAny: [],
       });
     });
-    // Fails...
+    
     it('can be used to allow a key with ["string"]', function () {
       expectValid(schema, {
         testAny: ['string'],
+      });
+    });
+    it('can be used to allow a key with { }', function () {
+      expectValid(schema, {
+        testAny: {},
       });
     });
     it('can be used to allow a key with { test: true }', function () {
       expectValid(schema, {
         testAny: { test: true },
       });
+    });
+    it('can be used to allow a key with { test: true }', function () {
+      expectValid(
+        new SimpleSchema({
+          testNested: schema,
+        }),
+        {
+          testNested: { testAny: { test: true } },
+        }
+      );
     });
     it('can be used to allow a key with NaN', function () {
       expectValid(schema, {

--- a/package/lib/doValidation.js
+++ b/package/lib/doValidation.js
@@ -123,6 +123,9 @@ function doValidation({
     // Loop through each of the definitions in the SimpleSchemaGroup.
     // If any return true, we're valid.
     const fieldIsValid = def.type.some(typeDef => {
+      // If the type is SimpleSchema.Any, then it is valid:
+      if (typeDef === SimpleSchema.Any) return true;
+
       const finalValidatorContext = {
         ...validatorContext,
 


### PR DESCRIPTION
This is a first pass commit to gather feedback.

It currently works for all types, but not for values inside an array or object. Which raises the question, should `type: SimpleSchema.Any` keys be treated as a blackbox by default too?

