### PR TITLE
Prevent the getAllowedValuesForKey function from throwing errors if no allowedValues are specified

### DIFF
--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -568,7 +568,13 @@ class SimpleSchema {
       key = `${key}.$`;
     }
 
-    return [...this.get(key, 'allowedValues')];
+    // `undefined` and `null` are not iterable
+    const allowedValues = this.get(key, 'allowedValues');
+    if (allowedValues) {
+      return [...allowedValues];
+    } else {
+      return undefined;
+    }
   }
 
   newContext() {


### PR DESCRIPTION
Since `undefined` and `null` are not iterable, this function throws an error when `allowedValues` is not specified in the schema. This function, however, is called regardless of the existence of this field by Meteor Autoform (https://github.com/aldeed/meteor-autoform). This causes various types of fields to not render. This simple fix should prevent errors without changing the functionality.