### PR TITLE
setAutoValues should preserve original field order for the same depth

### DIFF
--- a/package/lib/clean/setAutoValues.tests.js
+++ b/package/lib/clean/setAutoValues.tests.js
@@ -1,0 +1,69 @@
+import expect from 'expect';
+import { SimpleSchema } from '../SimpleSchema';
+import { sortAutoValueFunctions } from './setAutoValues';
+
+describe('setAutoValues', () => {
+  it('sorts correctly', () => {
+    const schema = new SimpleSchema({
+      field1: {
+        type: String,
+        autoValue() {},
+      },
+      field2: {
+        type: String,
+        autoValue() {},
+      },
+      field3: {
+        type: Number,
+        autoValue() {},
+      },
+      nested: Object,
+      'nested.field1': {
+        type: String,
+        autoValue() {},
+      },
+      'nested.field2': {
+        type: String,
+        autoValue() {},
+      },
+      'nested.field3': {
+        type: String,
+        autoValue() {},
+      },
+      'nested.field4': {
+        type: String,
+        defaultValue: 'test',
+      },
+      field4: {
+        type: Number,
+        autoValue() {},
+      },
+      field5: {
+        type: Number,
+        autoValue() {},
+      },
+      field6: {
+        type: String,
+        autoValue() {},
+      },
+      field7: {
+        type: String,
+        autoValue() {},
+      },
+    });
+
+    const autoValueFunctions = schema.autoValueFunctions();
+    const sorted = sortAutoValueFunctions(autoValueFunctions);
+
+    const FIELD_COUNT = 7;
+    const NESTED_FIELD_COUNT = 4;
+    // expecting: field1, field2, ..., field7, nested.field1, ... nested.field4
+    const fieldOrder = sorted.map(({ fieldName }) => fieldName);
+    for (let i = 0; i < FIELD_COUNT; ++i) {
+      expect(fieldOrder[i]).toBe(`field${i + 1}`);
+    }
+    for (let i = FIELD_COUNT; i < FIELD_COUNT + NESTED_FIELD_COUNT; ++i) {
+      expect(fieldOrder[i]).toBe(`nested.field${i - FIELD_COUNT + 1}`);
+    }
+  });
+});


### PR DESCRIPTION
Order of the autoValue functions may be random when doing setAutoValues while cleaning. The problem is that the Array.sort() is [not necessarily stable](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
As a consequence, some field's autoValue function that depends on some other field's autoValue does not work properly (sometimes, but randomly, depending on the count of the fields in the schema).

This PR changes the way the function objects are sorted so that we are sure the correct order at the same field depth is preserved.

Note that in the test that I've added, the are 11 fields because below that number the order was preserved by the Array.sort().

Might be the fix for #227 