### PR TITLE
Fix MongoError conflict error

### DIFF
--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -894,16 +894,16 @@ function getDefaultAutoValueFunction(defaultValue) {
     if (this.isSet) return;
     if (this.operator === null) return defaultValue;
 
-    // Handle the case when pulling an object from an array the object contains a field
-    // which has a defaultValue. We don't wan't the default value to be returned in this case
-    if (this.operator === '$pull' || this.isUpdate) return;
-
     // Handle the case where we are $pushing an object into an array of objects and we
     // want any fields missing from that object to be added if they have default values
     if (this.operator === '$push') return defaultValue;
 
     // If parent is set, we should update this position instead of $setOnInsert
     if (this.parentField().isSet) return defaultValue;
+
+    // Handle the case when pulling an object from an array the object contains a field
+    // which has a defaultValue. We don't wan't the default value to be returned in this case
+    if (this.operator === '$pull' || this.isUpdate) return;
 
     // We don't know whether it's an upsert, but if it's not, this seems to be ignored,
     // so this is a safe way to make sure the default value is added on upsert insert.

--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -898,12 +898,12 @@ function getDefaultAutoValueFunction(defaultValue) {
     // want any fields missing from that object to be added if they have default values
     if (this.operator === '$push') return defaultValue;
 
-    // If parent is set, we should update this position instead of $setOnInsert
-    if (this.parentField().isSet) return defaultValue;
-
     // Handle the case when pulling an object from an array the object contains a field
     // which has a defaultValue. We don't wan't the default value to be returned in this case
     if (this.operator === '$pull' || this.isUpdate) return;
+
+    // If parent is set, we should update this position instead of $setOnInsert
+    if (this.parentField().isSet) return defaultValue;
 
     // We don't know whether it's an upsert, but if it's not, this seems to be ignored,
     // so this is a safe way to make sure the default value is added on upsert insert.

--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -896,7 +896,7 @@ function getDefaultAutoValueFunction(defaultValue) {
 
     // Handle the case when pulling an object from an array the object contains a field
     // which has a defaultValue. We don't wan't the default value to be returned in this case
-    if (this.operator === '$pull') return;
+    if (this.operator === '$pull' || this.isUpdate) return;
 
     // Handle the case where we are $pushing an object into an array of objects and we
     // want any fields missing from that object to be added if they have default values

--- a/package/package-lock.json
+++ b/package/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "simpl-schema",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1335,6 +1335,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
       "dev": true,
+      "optional": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -1486,7 +1487,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -1892,7 +1894,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
       "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -3079,13 +3082,15 @@
       "version": "1.27.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
       "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "mime-types": {
       "version": "2.1.15",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
       "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
       "dev": true,
+      "optional": true,
       "requires": {
         "mime-db": "~1.27.0"
       }


### PR DESCRIPTION
With the latest version of Mongo, `$setOnInsert` creates a conflict on update which throws an error `MongoError: Updating the path 'pathName' would create a conflict at 'pathName' }` (see [this issue](https://github.com/meteor/meteor/issues/10168)). Skipping it seems to fix the problem.