### PR TITLE
returns null when allowedValues key is empty

### DIFF
--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -2,6 +2,7 @@ import extend from 'extend';
 import MongoObject from 'mongo-object';
 import omit from 'lodash.omit';
 import every from 'lodash.every';
+import isEmpty from 'lodash.isempty';
 import pick from 'lodash.pick';
 import uniq from 'lodash.uniq';
 import MessageBox from 'message-box';
@@ -567,8 +568,8 @@ class SimpleSchema {
     if (this.allowsKey(`${key}.$`)) {
       key = `${key}.$`;
     }
-
-    return [...this.get(key, 'allowedValues')];
+    const allowedValues = this.get(key, 'allowedValues');
+    return isEmpty(allowedValues) ? null : [...allowedValues];
   }
 
   newContext() {

--- a/package/lib/SimpleSchema_allowedValues.tests.js
+++ b/package/lib/SimpleSchema_allowedValues.tests.js
@@ -391,5 +391,15 @@ describe('SimpleSchema - allowedValues', function () {
       expect(fetchedAllowedValues).toInclude('b');
       expect(fetchedAllowedValues.length).toEqual(2);
     });
+
+    it('returns null when allowedValues key is empty', function () {
+      const schema = new SimpleSchema({
+        foo: Array,
+        'foo.$': {
+          type: String,
+        },
+      });
+      expect(schema.getAllowedValuesForKey('foo')).toEqual(null);
+    });
   });
 });


### PR DESCRIPTION
this fixes bug that when the field has no allowedValues key the schema will throw error 
```
TypeError: Cannot convert undefined or null to object
```

this pull request targets issue aldeed/meteor-autoform#1654