### PR TITLE
Fix #307 - Test for empty object when creating schema

### DIFF
--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -6,6 +6,7 @@ import pick from 'lodash.pick';
 import uniq from 'lodash.uniq';
 import MessageBox from 'message-box';
 import includes from 'lodash.includes';
+import isEmpty from 'lodash.isempty';
 import clone from 'clone';
 import humanize from './humanize.js';
 import ValidationContext from './ValidationContext';
@@ -946,6 +947,10 @@ function checkAndScrubDefinition(fieldName, definition, options, fullSchemaObj) 
 
     if (Array.isArray(type)) {
       throw new Error(`Invalid definition for ${fieldName} field: "type" may not be an array. Change it to Array.`);
+    }
+
+    if (type.constructor === Object && isEmpty(type)) {
+      throw new Error(`Invalid definition for ${fieldName} field: "type" may not be an object. Change it to Object`);
     }
 
     if (type === Array) couldBeArray = true;

--- a/package/lib/SimpleSchema.tests.js
+++ b/package/lib/SimpleSchema.tests.js
@@ -199,6 +199,23 @@ describe('SimpleSchema', function () {
         },
       ]);
     });
+
+    it('issue #307 - throws an error if incorrect import results in empty object', function () {
+      expect(function () {
+        // Assume that default import of a file with no default export returns an empty object
+        const Place = {};
+
+        // eslint-disable-next-line no-new
+        new SimpleSchema({
+          places: {
+            type: Array,
+            label: 'Places',
+            optional: true,
+          },
+          'places.$': { type: Place },
+        });
+      }).toThrow('Invalid definition for places.$ field: "type" may not be an object. Change it to Object');
+    });
   });
 
   it('Safely sets defaultValues on subschemas nested in arrays', function () {


### PR DESCRIPTION
Issue #307 is caused because if you try to import a file with no
exports in ESM, it returns an empty object. This is probably to achieve
interop with CJS, which initializes `module.exports` to an empty object.
This empty object passed validation checks because empty objects are
truthy, and no specific check exists.

To solve this, I've added a specific checks for empty objects in
`checkAndScrubDefinition` (I tried using lodash's isObject, but that
returned true for all type constructors, which also return true for
isEmpty 🤷‍♂️).

From the docs it doesn't look like a plain object is ever a valid type,
so I don't believe this should break anything for anyone else

Happy Hacktoberfest!