### PR TITLE
Fix issue #294 - Prevent clean from changing a valid type from a oneOf group

### DIFF
--- a/package/lib/SimpleSchema_oneOf.tests.js
+++ b/package/lib/SimpleSchema_oneOf.tests.js
@@ -7,20 +7,32 @@ describe('SimpleSchema', function () {
   describe('oneOf', function () {
     it('allows either type', function () {
       const schema = new SimpleSchema({
-        foo: SimpleSchema.oneOf(String, Number),
+        foo: SimpleSchema.oneOf(String, Number, Date),
       });
 
-      expect(function () {
-        schema.validate({ foo: 1 });
+      const test1 = { foo: 1 };
+      expect(function test1func () {
+        schema.validate(test1);
       }).toNotThrow();
+      expect(test1.foo).toBeA('number');
 
-      expect(function () {
-        schema.validate({ foo: 'bar' });
+      const test2 = { foo: 'bar' };
+      expect(function test2func () {
+        schema.validate(test2);
       }).toNotThrow();
+      expect(test2.foo).toBeA('string');
 
-      expect(function () {
-        schema.validate({ foo: false });
+      const test3 = { foo: new Date() };
+      expect(function test2func () {
+        schema.validate(test3);
+      }).toNotThrow();
+      expect(test3.foo instanceof Date).toBe(true);
+
+      const test4 = { foo: false };
+      expect(function test3func () {
+        schema.validate(test4);
       }).toThrow();
+      expect(test4.foo).toBeA('boolean');
     });
 
     it.skip('allows either type including schemas', function () {

--- a/package/lib/clean.js
+++ b/package/lib/clean.js
@@ -5,6 +5,7 @@ import { looksLikeModifier } from './utility';
 import { SimpleSchema } from './SimpleSchema';
 import convertToProperType from './clean/convertToProperType';
 import setAutoValues from './clean/setAutoValues';
+import typeValidator from './validation/typeValidator';
 
 /**
  * @param {SimpleSchema} ss - A SimpleSchema instance
@@ -74,15 +75,27 @@ function clean(ss, doc, options = {}) {
       }
 
       const outerDef = ss.schema(gKey);
-      const def = outerDef && outerDef.type.definitions[0];
+      const defs = outerDef && outerDef.type.definitions;
+      const def = defs && defs[0];
 
       // Autoconvert values if requested and if possible
       if (options.autoConvert && def) {
-        const newVal = convertToProperType(val, def.type);
-        if (newVal !== undefined && newVal !== val) {
-          SimpleSchema.debug && console.info(`SimpleSchema.clean: autoconverted value ${val} from ${typeof val} to ${typeof newVal} for ${gKey}`);
-          val = newVal;
-          this.updateValue(newVal);
+        const isValidType = defs.some(definition => {
+          const errors = typeValidator.call({
+            valueShouldBeChecked: true,
+            definition,
+            value: val,
+          });
+          return errors === undefined;
+        });
+
+        if (!isValidType) {
+          const newVal = convertToProperType(val, def.type);
+          if (newVal !== undefined && newVal !== val) {
+            SimpleSchema.debug && console.info(`SimpleSchema.clean: autoconverted value ${val} from ${typeof val} to ${typeof newVal} for ${gKey}`);
+            val = newVal;
+            this.updateValue(newVal);
+          }
         }
       }
 

--- a/package/lib/clean.tests.js
+++ b/package/lib/clean.tests.js
@@ -589,6 +589,10 @@ describe('clean', function () {
       field: {
         type: SimpleSchema.oneOf(String, Number, Date),
       },
+      nested: {
+        type: Object,
+      },
+      'nested.field': SimpleSchema.oneOf(String, Number, Date),
     });
 
     function doTest(given, expected) {
@@ -642,11 +646,28 @@ describe('clean', function () {
       it('should not convert a string', function () {
         doTest({ $set: { field: 'I am a string' } }, { $set: { field: 'I am a string' } });
       });
+      it('should not convert a nested string', function () {
+        doTest({ $set: { field: 'I am a string' } }, { $set: { field: 'I am a string' } });
+      });
       it('should not convert a number', function () {
         doTest({ $set: { field: 12345 } }, { $set: { field: 12345 } });
       });
       it('should not convert a Date', function () {
         doTest({ $set: { field: new Date(12345) } }, { $set: { field: new Date(12345) } });
+      });
+      describe('nested operator', function () {
+        it('should not convert a string', function () {
+          doTest({ $set: { 'nested.field': 'I am a string' } }, { $set: { 'nested.field': 'I am a string' } });
+        });
+        it('should not convert a nested string', function () {
+          doTest({ $set: { 'nested.field': 'I am a string' } }, { $set: { 'nested.field': 'I am a string' } });
+        });
+        it('should not convert a number', function () {
+          doTest({ $set: { 'nested.field': 12345 } }, { $set: { 'nested.field': 12345 } });
+        });
+        it('should not convert a Date', function () {
+          doTest({ $set: { 'nested.field': new Date(12345) } }, { $set: { 'nested.field': new Date(12345) } });
+        });
       });
       it('should convert a Date if no Date in oneOf', function () {
         const schemaNoDate = new SimpleSchema({

--- a/package/lib/clean.tests.js
+++ b/package/lib/clean.tests.js
@@ -583,4 +583,27 @@ describe('clean', function () {
       },
     });
   });
+
+  describe('with SimpleSchema.oneOf(String, Number, Date)', function () {
+    const oneOfSchema = new SimpleSchema({
+      field: {
+        type: SimpleSchema.oneOf(String, Number, Date),
+      },
+    });
+
+    function doTest(given, expected) {
+      const cleanObj = oneOfSchema.clean(given, { mutate: true });
+      expect(cleanObj).toEqual(expected);
+    }
+
+    it('should not convert a string', function () {
+      doTest({ field: 'I am a string' }, { field: 'I am a string' });
+    });
+    it('should not convert a number', function () {
+      doTest({ field: 12345 }, { field: 12345 });
+    });
+    it('should not convert a Date', function () {
+      doTest({ field: new Date(12345) }, { field: new Date(12345) });
+    });
+  });
 });

--- a/package/lib/clean.tests.js
+++ b/package/lib/clean.tests.js
@@ -605,5 +605,81 @@ describe('clean', function () {
     it('should not convert a Date', function () {
       doTest({ field: new Date(12345) }, { field: new Date(12345) });
     });
+    it('should convert a Date if no Date in oneOf', function () {
+      const schemaNoDate = new SimpleSchema({
+        field: {
+          type: SimpleSchema.oneOf(String, Number),
+        },
+      });
+      const date = new Date(12345);
+      const dateStrng = date.toString();
+
+      const cleanObj = schemaNoDate.clean({ field: date }, { mutate: true });
+      expect(cleanObj).toEqual({ field: dateStrng });
+    });
+    it('should convert a String if no String in oneOf', function () {
+      const schemaNoDate = new SimpleSchema({
+        field: {
+          type: SimpleSchema.oneOf(Number, Date),
+        },
+      });
+
+      const cleanObj = schemaNoDate.clean({ field: '12345' }, { mutate: true });
+      expect(cleanObj).toEqual({ field: 12345 });
+    });
+    it('should convert a Number if no Number in oneOf', function () {
+      const schemaNoDate = new SimpleSchema({
+        field: {
+          type: SimpleSchema.oneOf(String, Date),
+        },
+      });
+
+      const cleanObj = schemaNoDate.clean({ field: 12345 }, { mutate: true });
+      expect(cleanObj).toEqual({ field: '12345' });
+    });
+
+    describe('with modifiers', function () {
+      it('should not convert a string', function () {
+        doTest({ $set: { field: 'I am a string' } }, { $set: { field: 'I am a string' } });
+      });
+      it('should not convert a number', function () {
+        doTest({ $set: { field: 12345 } }, { $set: { field: 12345 } });
+      });
+      it('should not convert a Date', function () {
+        doTest({ $set: { field: new Date(12345) } }, { $set: { field: new Date(12345) } });
+      });
+      it('should convert a Date if no Date in oneOf', function () {
+        const schemaNoDate = new SimpleSchema({
+          field: {
+            type: SimpleSchema.oneOf(String, Number),
+          },
+        });
+        const date = new Date(12345);
+        const dateString = date.toString();
+
+        const cleanObj = schemaNoDate.clean({ $set: { field: date } }, { mutate: true });
+        expect(cleanObj).toEqual({ $set: { field: dateString } });
+      });
+      it('should convert a String if no String in oneOf', function () {
+        const schemaNoDate = new SimpleSchema({
+          field: {
+            type: SimpleSchema.oneOf(Number, Date),
+          },
+        });
+
+        const cleanObj = schemaNoDate.clean({ $set: { field: '12345' } }, { mutate: true });
+        expect(cleanObj).toEqual({ $set: { field: 12345 } });
+      });
+      it('should convert a Number if no Number in oneOf', function () {
+        const schemaNoDate = new SimpleSchema({
+          field: {
+            type: SimpleSchema.oneOf(String, Date),
+          },
+        });
+
+        const cleanObj = schemaNoDate.clean({ $set: { field: 12345 } }, { mutate: true });
+        expect(cleanObj).toEqual({ $set: { field: '12345' } });
+      });
+    });
   });
 });


### PR DESCRIPTION
Context is in the thread of #294 

Fairly simple solution was to validate each value before, to check if conversion is required before continuing.

Not sure if this is the most efficient, as type validation will now take place during cleaning and again in post cleaning validation. 
If you prefer, I can change it to perform more primitive type checking instead of using the `typeValidator` function.
Alternatively we could check the length of the `defs` array before testing types?

Happy Hacktoberfest!