### PR TITLE
Allow mapping over all schema fields

### DIFF
--- a/package/lib/SimpleSchema.js
+++ b/package/lib/SimpleSchema.js
@@ -772,10 +772,29 @@ class SimpleSchema {
 
   /**
    * @method SimpleSchema#omit
+   *
    * @param {[fields]} The list of fields to omit to instantiate the subschema
    * @returns {SimpleSchema} The subschema
    */
   omit = getPickOrOmit('omit');
+
+  /**
+   * Maps over the schema's keys and returns a new schema
+   *
+   * @param {iteratee} A function to call on each field, with signature: (key, field) => field
+   * If it returns falsy, the old field is kept instead.
+   * @returns {SimpleSchema} A new simpleschema
+   */
+  map(iteratee) {
+   const oldSchema = this.schema();
+   const mappedSchema = Object.keys(oldSchema).reduce((obj, key) => {
+     const oldField = oldSchema[key]
+     const newField = iteratee(key, oldField);
+     return { ...obj, [key]: newField || oldField };
+   }, {})
+   
+   return new SimpleSchema(mappedSchema, { ...this._constructorOptions, ...this._cleanOptions });
+  }
 
   static version = 2;
 


### PR DESCRIPTION
I've had to modify schemas at once a few times, and I don't think there's a clean way of doing it? 

This is a proposal for a new `map` method on a schema, that returns a new schema after mapping over each key.

Todo:
* [ ] Find out if this is useful
* [ ] Tests
* [ ] Figure out if we should provide options, such as mapping over all nested fields as well?
* [ ] Document this